### PR TITLE
Rename "option" block parameters to "opt"

### DIFF
--- a/addon/templates/components/ember-chosen.hbs
+++ b/addon/templates/components/ember-chosen.hbs
@@ -12,8 +12,8 @@
       {{#if validGroupPath}}
         {{#each options as |group|}}
           <optgroup label={{group.label}}>
-            {{#each group.options as |option|}}
-              <option value={{option.value}} selected="{{if option.selected 'selected'}}">{{option.label}}</option>
+            {{#each group.options as |opt|}}
+              <option value={{opt.value}} selected="{{if opt.selected 'selected'}}">{{opt.label}}</option>
             {{else}}
               <option disabled>No Options Available</option>
             {{/each}}
@@ -22,8 +22,8 @@
           <option disabled>No Options Available</option>
         {{/each}}
       {{else}}
-        {{#each options as |option|}}
-          <option value={{option.value}} selected="{{if option.selected 'selected'}}">{{option.label}}</option>
+        {{#each options as |opt|}}
+          <option value={{opt.value}} selected="{{if opt.selected 'selected'}}">{{opt.label}}</option>
         {{else}}
           <option disabled>No Options Available</option>
         {{/each}}


### PR DESCRIPTION
With the introduction of dynamic angle bracket component invocation,
HTML tag names should no longer be used as block params.

This restores compatibility with Ember 3.3.0+

See [RFC 311](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md#dynamic-invocations) and [16826](https://github.com/emberjs/ember.js/issues/16826) for more info. 